### PR TITLE
Remove redundant symfony/polyfill-php80 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
 		"symfony/intl": "^5 || ^6",
 		"symfony/options-resolver": "^5 || ^6 || ^7",
 		"symfony/polyfill-mbstring": "^1",
-		"symfony/polyfill-php80": "^1.23.0",
 		"typo3/cms-backend": "^11.5 || ^12.4",
 		"typo3/cms-core": "^11.5 || ^12.4",
 		"typo3/cms-extbase": "^11.5 || ^12.4",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php80`, but also `php: ^8.0`, so the polyfill requirement doesn't seem necessary anymore?